### PR TITLE
Send 4-button events via event queue

### DIFF
--- a/main/FourButtons.cpp
+++ b/main/FourButtons.cpp
@@ -1,8 +1,7 @@
 #include "FourButtons.h"
-#include <stdio.h>
 
-FourButtons::FourButtons(const ButtonSpec specs[4], int debounceMs, bool activeLow)
-    : debounceMs_(debounceMs), activeLow_(activeLow) {
+FourButtons::FourButtons(const ButtonSpec specs[4], EventQueue& bus, int debounceMs, bool activeLow)
+    : bus_(bus), debounceMs_(debounceMs), activeLow_(activeLow) {
     for (int i = 0; i < 4; ++i) {
         btn_[i] = specs[i];
 
@@ -37,8 +36,11 @@ void FourButtons::poll(int dtMs) {
             timerMs_[i] += dtMs;
             if (timerMs_[i] >= debounceMs_ && rawDown != stableDown_[i]) {
                 stableDown_[i] = rawDown;
-                // Print exactly one line per stable edge
-                printf("BTN,%u,%s\n", btn_[i].id, stableDown_[i] ? "DOWN" : "UP");
+                Event e;
+                e.type = EventType::ButtonEdge;
+                e.id = btn_[i].id;
+                e.data.down = stableDown_[i];
+                bus_.send(e);
             }
         }
     }

--- a/main/FourButtons.h
+++ b/main/FourButtons.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <stdint.h>
 #include "driver/gpio.h"
+#include "EventQueue.h"
 
 // One struct per button: which pin and which ID to print.
 struct ButtonSpec {
@@ -12,15 +13,17 @@ struct ButtonSpec {
 class FourButtons {
 public:
     // specs: 4 entries. debounceMs typical 30. activeLow=true for pull-ups.
-    FourButtons(const ButtonSpec specs[4], int debounceMs, bool activeLow = true);
+    // Events for each edge are sent to bus with type ButtonEdge and id from specs.
+    FourButtons(const ButtonSpec specs[4], EventQueue& bus, int debounceMs, bool activeLow = true);
 
     // Call this every dtMs (e.g., dtMs = 5 in a FreeRTOS loop).
     void poll(int dtMs);
 
 private:
-    ButtonSpec btn_[4];
-    int  debounceMs_;
-    bool activeLow_;
+    ButtonSpec   btn_[4];
+    EventQueue&  bus_;
+    int          debounceMs_;
+    bool         activeLow_;
 
     // state per button
     bool lastRaw_[4] = { false,false,false,false };

--- a/main/app_main.cpp
+++ b/main/app_main.cpp
@@ -34,7 +34,7 @@ extern "C" void app_main(void) {
         { GPIO_NUM_40, 13 },
         { GPIO_NUM_39, 14 },
     };
-    static FourButtons four(four_specs, /*debounceMs=*/30, /*activeLow=*/true);
+    static FourButtons four(four_specs, bus, /*debounceMs=*/30, /*activeLow=*/true);
 
     ESP_LOGI(TAG, "Polling every %d ms; UART @ 115200", cfg::POLL_PERIOD_MS);
     ESP_LOGI(TAG, "Messages: BTN,<id>,DOWN/UP | POT,<id>,1..8");
@@ -44,7 +44,7 @@ extern "C" void app_main(void) {
         btn.poll(cfg::POLL_PERIOD_MS);
         pot.poll(cfg::POLL_PERIOD_MS);
 
-        // ADDED: poll the 4 buttons (prints BTN,11..14,DOWN/UP)
+        // ADDED: poll the 4 buttons (events BTN,11..14,DOWN/UP)
         four.poll(cfg::POLL_PERIOD_MS);
 
         vTaskDelay(period);


### PR DESCRIPTION
## Summary
- send FourButtons edge events through EventQueue
- wire FourButtons into app_main using the event bus

## Testing
- `idf.py build` *(fails: command not found)*
- `cmake -S . -B build` *(fails: source directory missing CMakeLists.txt)*


------
https://chatgpt.com/codex/tasks/task_e_689ce080d5ac8323ab4371e7985bf006