### PR TITLE
Avoid BTN1 pin overlap for four-button block

### DIFF
--- a/main/Config.h
+++ b/main/Config.h
@@ -9,10 +9,22 @@ namespace cfg {
 // Identifiers used when sending events
 static const uint8_t BTN1_ID = 1; // single button ID
 static const uint8_t POT1_ID = 2; // potentiometer ID
+static const uint8_t BTN4_IDS[4] = { 11, 12, 13, 14 }; // four-button block IDs
 
 // GPIO assignments
 static const gpio_num_t BTN1_PIN = GPIO_NUM_42; // user push button
 static const gpio_num_t LED1_PIN = GPIO_NUM_5;  // indicator LED
+static const gpio_num_t BTN4_PINS[4] = {
+    GPIO_NUM_41, // B1
+    GPIO_NUM_40, // B2
+    GPIO_NUM_39, // B3
+    GPIO_NUM_38  // B4
+};
+
+// Final pin layout:
+//   BTN1_PIN (ID 1) -> GPIO42
+//   Four-button block (IDs 11-14) -> GPIO41, GPIO40, GPIO39, GPIO38
+//   LED1_PIN -> GPIO5
 
 // ADC configuration for the potentiometer
 static const adc_unit_t    POT_UNIT = ADC_UNIT_1;

--- a/main/app_main.cpp
+++ b/main/app_main.cpp
@@ -40,15 +40,14 @@ extern "C" void app_main(void) {
     tx.startTask("serial_tx", 4096, 1);  // keep low prio
 
 
-    // Four additional buttons (active-low with internal pull-ups).  IDs are
-    // chosen to avoid collision with existing BTN1_ID.
-    // 4-button block (active-low with internal pull-ups)
-
+    // Four additional buttons (active-low with internal pull-ups).
+    // Pins avoid cfg::BTN1_PIN and map to IDs 11-14 as shown below:
+    //   GPIO41->ID11, GPIO40->ID12, GPIO39->ID13, GPIO38->ID14
     static const ButtonSpec four_specs[4] = {
-        { GPIO_NUM_42, 11 },
-        { GPIO_NUM_41, 12 },
-        { GPIO_NUM_40, 13 },
-        { GPIO_NUM_39, 14 },
+        { cfg::BTN4_PINS[0], cfg::BTN4_IDS[0] },
+        { cfg::BTN4_PINS[1], cfg::BTN4_IDS[1] },
+        { cfg::BTN4_PINS[2], cfg::BTN4_IDS[2] },
+        { cfg::BTN4_PINS[3], cfg::BTN4_IDS[3] },
     };
     static FourButtons four(four_specs, bus, /*debounceMs=*/30, /*activeLow=*/true);
 


### PR DESCRIPTION
## Summary
- define BTN4_IDS and BTN4_PINS in Config.h and document final pin layout
- use cfg::BTN4_* in app_main.cpp so four-button pins (GPIO41-38) don't conflict with BTN1_PIN

## Testing
- `idf.py build` *(fails: command not found)*
- `cmake .` *(fails: no CMakeLists.txt at repo root)*

------
https://chatgpt.com/codex/tasks/task_e_689da01c6e648323a017ce7fc986832c