### PR TITLE
Document public headers with Doxygen comments

### DIFF
--- a/main/Button.h
+++ b/main/Button.h
@@ -1,31 +1,40 @@
-// Button.h - declaration of a debounced push button helper
-//
-// Each Button instance monitors a GPIO input and posts an event to an
-// EventQueue whenever the button state changes.  An optional LED can be
-// "mirrored" so that the LED follows the button state.  The implementation
-// performs simple software debouncing based on a poll interval provided by
-// the caller.
+/**
+ * @file Button.h
+ * @brief Declaration of a debounced push button helper.
+ *
+ * Each Button instance monitors a GPIO input and posts an event to an
+ * EventQueue whenever the button state changes. An optional LED can be
+ * "mirrored" so that the LED follows the button state. The implementation
+ * performs simple software debouncing based on a poll interval provided by
+ * the caller.
+ */
 
 #pragma once
 #include <stdint.h>
 #include "driver/gpio.h"
 #include "EventQueue.h"
 
-// Forward declaration to avoid circular include
+/** Forward declaration to avoid circular include. */
 class Led;
 
-// Represents a single debounced button connected to a GPIO pin.
+/** @brief Represents a single debounced button connected to a GPIO pin. */
 class Button {
 public:
-    // Construct a button on the given pin.  "id" is used in generated events.
-    // "bus" is where events are posted.  "debounceMs" specifies the minimum
-    // time a level must be stable before an edge is reported.  If "mirror" is
-    // provided the LED's state is updated to match the button.
+    /**
+     * @brief Construct a button on the given pin.
+     * @param pin GPIO pin connected to the button.
+     * @param id Identifier used when generating events.
+     * @param bus Queue to which events are posted.
+     * @param debounceMs Minimum time a level must be stable before reporting.
+     * @param mirror Optional LED whose state mirrors the button.
+     */
     Button(gpio_num_t pin, uint8_t id, EventQueue& bus, int debounceMs,
            Led* mirror = nullptr);
 
-    // Poll the hardware.  Call this periodically with the elapsed time in
-    // milliseconds since the last call.
+    /**
+     * @brief Poll the hardware.
+     * @param dtMs Elapsed time in milliseconds since the last call.
+     */
     void poll(int dtMs);
 
 private:

--- a/main/EventQueue.h
+++ b/main/EventQueue.h
@@ -1,24 +1,41 @@
-// EventQueue.h - thin wrapper around a FreeRTOS queue for Event objects
+/**
+ * @file EventQueue.h
+ * @brief Thin wrapper around a FreeRTOS queue for Event objects.
+ */
 
 #pragma once
 #include "freertos/FreeRTOS.h"
 #include "freertos/queue.h"
 #include "Event.h"
 
-// Provides send/receive helpers with type safety for Event structures
+/** @brief Provides send/receive helpers with type safety for Event structures. */
 class EventQueue {
 public:
-    // Create a queue capable of holding "capacity" events
+    /**
+     * @brief Create a queue capable of holding a number of events.
+     * @param capacity Maximum number of events the queue can hold.
+     */
     explicit EventQueue(unsigned capacity = 32);
 
-    // Send an event to the queue.  Returns true on success.
+    /**
+     * @brief Send an event to the queue.
+     * @param e Event to send.
+     * @return true on success.
+     */
     bool send(const Event& e);
 
-    // Receive an event from the queue, waiting up to "toTicks" ticks.
-    // Returns true if an event was received.
+    /**
+     * @brief Receive an event from the queue.
+     * @param e Event object to populate.
+     * @param toTicks Maximum number of ticks to wait.
+     * @return true if an event was received.
+     */
     bool recv(Event& e, TickType_t toTicks);
 
-    // Access the underlying FreeRTOS queue handle
+    /**
+     * @brief Access the underlying FreeRTOS queue handle.
+     * @return Native queue handle.
+     */
     QueueHandle_t handle() const { return q_; }
 
 private:

--- a/main/FourButtons.h
+++ b/main/FourButtons.h
@@ -1,27 +1,41 @@
-// FourButtons.h - helper for reading four debounced buttons
+/**
+ * @file FourButtons.h
+ * @brief Helper for reading four debounced buttons.
+ */
 
 #pragma once
 #include <stdint.h>
 #include "driver/gpio.h"
 #include "EventQueue.h"
 
-// One struct per button: which pin is used and which ID to report in events.
+/** @brief One struct per button specifying the GPIO pin and event ID. */
 struct ButtonSpec {
-    gpio_num_t pin; // GPIO pin the button is connected to
-    uint8_t    id;  // Identifier printed when the button changes state
+    gpio_num_t pin; ///< GPIO pin the button is connected to
+    uint8_t    id;  ///< Identifier printed when the button changes state
 };
 
-// Debounced 4-button reader. Active-LOW by default (internal pull-ups on).
-// The class polls all four buttons and prints a line on the UART whenever
-// a stable edge is detected.
+/**
+ * @brief Debounced four-button reader.
+ *
+ * Active-LOW by default (internal pull-ups on). The class polls all four
+ * buttons and prints a line on the UART whenever a stable edge is detected.
+ */
 class FourButtons {
 public:
-    // specs: 4 entries. debounceMs typical 30. activeLow=true for pull-ups.
-    // Events for each edge are sent to bus with type ButtonEdge and id from specs.
+    /**
+     * @brief Construct with button specifications and event queue.
+     * @param specs Array of four button specifications.
+     * @param bus Event queue where button events are sent.
+     * @param debounceMs Minimum stable time in milliseconds to accept an edge.
+     * @param activeLow True if buttons are active-low.
+     */
     FourButtons(const ButtonSpec specs[4], EventQueue& bus, int debounceMs, bool activeLow = true);
 
 
-    // Call this every dtMs (e.g., dtMs = 5 in a FreeRTOS loop).
+    /**
+     * @brief Poll all buttons and send events on edges.
+     * @param dtMs Elapsed time in milliseconds since the last call.
+     */
     void poll(int dtMs);
 
 private:

--- a/main/Led.h
+++ b/main/Led.h
@@ -1,21 +1,35 @@
-// Led.h - simple GPIO output wrapper used for indicator LEDs
+/**
+ * @file Led.h
+ * @brief Simple GPIO output wrapper used for indicator LEDs.
+ */
 
 #pragma once
 #include "driver/gpio.h"
 
-// Minimal class providing on/off/toggle control of a GPIO pin
+/** @brief Minimal class providing on/off/toggle control of a GPIO pin. */
 class Led {
 public:
-    // Create a LED bound to the given GPIO pin
+    /**
+     * @brief Create a LED bound to the given GPIO pin.
+     * @param pin GPIO pin connected to the LED.
+     */
     explicit Led(gpio_num_t pin);
 
-    // Drive the pin HIGH when "on" is true, LOW otherwise
+    /**
+     * @brief Drive the pin HIGH when on is true, LOW otherwise.
+     * @param on Desired output state.
+     */
     void set(bool on);
 
-    // Convenience method to invert the current state
+    /**
+     * @brief Invert the current state.
+     */
     void toggle();
 
-    // Query the current state (true if HIGH)
+    /**
+     * @brief Query the current state.
+     * @return true if the pin is HIGH.
+     */
     bool get() const;
 
 private:

--- a/main/Potentiometer.h
+++ b/main/Potentiometer.h
@@ -1,24 +1,45 @@
-// Potentiometer.h - ADC-based potentiometer reader with bucketized events
+/**
+ * @file Potentiometer.h
+ * @brief ADC-based potentiometer reader with bucketized events.
+ */
 
 #pragma once
 #include <stdint.h>
 #include "esp_adc/adc_oneshot.h"
 #include "EventQueue.h"
 
-// Reads a potentiometer using the ESP32 one-shot ADC driver and reports the
-// value in coarse "buckets" to reduce serial traffic.
+/**
+ * @brief Reads a potentiometer using the ESP32 one-shot ADC driver and reports
+ * the value in coarse "buckets" to reduce serial traffic.
+ */
 class Potentiometer {
 public:
-    // "unit" and "ch" select the ADC unit/channel.  "id" identifies events
-    // sent to the EventQueue.  "reportIntervalMs" is the polling period.
+    /**
+     * @brief Initialize the potentiometer reader.
+     * @param unit ADC unit to use.
+     * @param ch ADC channel on the unit.
+     * @param id Identifier for generated events.
+     * @param bus Event queue to publish to.
+     * @param reportIntervalMs Polling period in milliseconds.
+     */
     Potentiometer(adc_unit_t unit, adc_channel_t ch, uint8_t id,
                   EventQueue& bus, int reportIntervalMs);
+    /**
+     * @brief Clean up the ADC driver.
+     */
     ~Potentiometer();
 
-    // Poll the ADC and send an event when the bucket changes
+    /**
+     * @brief Poll the ADC and send an event when the bucket changes.
+     * @param dtMs Elapsed time in milliseconds since the last call.
+     */
     void poll(int dtMs);
 
-    // Convert a raw ADC reading into one of eight buckets (1..8)
+    /**
+     * @brief Convert a raw ADC reading into one of eight buckets.
+     * @param raw Raw ADC reading.
+     * @return Bucket number from 1 to 8.
+     */
     static int bucket8(int raw);
 
 private:

--- a/main/SerialMessenger.h
+++ b/main/SerialMessenger.h
@@ -1,4 +1,7 @@
-// SerialMessenger.h - task that forwards events to the UART
+/**
+ * @file SerialMessenger.h
+ * @brief Task that forwards events to the UART.
+ */
 
 #pragma once
 #include <stdio.h>
@@ -6,22 +9,37 @@
 #include "freertos/task.h"
 #include "EventQueue.h"
 
-// Consumes events from an EventQueue and prints them to stdout.
-// Useful for debugging when connected to a serial terminal.
+/**
+ * @brief Consumes events from an EventQueue and prints them to stdout.
+ * Useful for debugging when connected to a serial terminal.
+ */
 class SerialMessenger {
 public:
-    // Construct with a reference to the EventQueue to listen on
+    /**
+     * @brief Construct with a reference to the EventQueue to listen on.
+     * @param bus EventQueue providing events.
+     */
     explicit SerialMessenger(EventQueue& bus);
 
-    // Launch the FreeRTOS task that waits for events and prints them
+    /**
+     * @brief Launch the FreeRTOS task that waits for events and prints them.
+     * @param name Task name.
+     * @param stack Stack size in bytes.
+     * @param prio Task priority.
+     */
     void startTask(const char* name = "serial_tx", uint32_t stack = 4096,
                    UBaseType_t prio = 5);
 
 private:
-    // Static trampoline used by xTaskCreate
+    /**
+     * @brief Static trampoline used by xTaskCreate.
+     * @param arg Pointer to SerialMessenger instance.
+     */
     static void taskTrampoline(void* arg);
 
-    // Main task body: receive and print events
+    /**
+     * @brief Main task body: receive and print events.
+     */
     void run();
 
     EventQueue& bus_; // queue from which events are read


### PR DESCRIPTION
## Summary
- convert header comments to Doxygen blocks with `@file` and `@brief`
- add `@param` and `@return` tags to public constructors and methods

## Testing
- `doxygen --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689dd2e0b8d0832381b0e35f580db789